### PR TITLE
fixed infinite loading of node server if request is not for socket.io

### DIFF
--- a/server/bundles/server.js
+++ b/server/bundles/server.js
@@ -8,6 +8,12 @@ const dotenv = require('dotenv').config();
 const server = args.ssl ? https.createServer({
     key: fs.readFileSync(ssl.key),
     cert: fs.readFileSync(ssl.cert)
-}) : http.createServer();
+}, (req, res) => {
+    res.writeHead(404);
+    res.end('');
+}) : http.createServer((req, res) => {
+    res.writeHead(404);
+    res.end('');
+});
 
 module.exports = server;


### PR DESCRIPTION
we found an issue where the node server would load infinitely until a proxy breaks the connection.

The solution was to change the server code to always return a 404 error if someone tries a different url. 